### PR TITLE
ENYO-3032: Correct the calls to the merge function.

### DIFF
--- a/src/Element.js
+++ b/src/Element.js
@@ -12,8 +12,6 @@ var
 	svgUtil = require('./utils')
 	;
 
-// console.log( "WTF IS WRONG");
-
 // Base-kind for deriving all SVG kinds
 module.exports = kind({
 	name: 'Element',
@@ -26,7 +24,7 @@ module.exports = kind({
 		attrs.conditionalProcessing,
 		[
 			'space',
-			'target', // Synnonym for xlink:href
+			'target', // Synonym for xlink:href
 			'transform',
 			'externalResourcesRequired'
 		]
@@ -44,7 +42,6 @@ module.exports = kind({
 
 		if (this.supportedAttributes) {
 			this.supportedAttributes.forEach(this.bindSafely(function (attr) {
-				// console.log("setting %s because its supported.", attr);
 				// Specially cased and aliased attributes
 				switch (attr) {
 					case 'space':
@@ -90,7 +87,7 @@ module.exports = kind({
 			attrs = this.supportedAttributes;
 
 		if (attrs && attrs.indexOf(attr) >= 0) {
-			// Transforms are special conditioning fro just the attribute conversion and application process.
+			// Transforms are special conditioning for just the attribute conversion and application process.
 			if (this.transforms && this.transforms[attr]) {
 				val = this.bindSafely(this.transforms[attr])(val, attr);
 			}

--- a/src/Group.js
+++ b/src/Group.js
@@ -1,20 +1,19 @@
 require('svg');
 
 var
-	kind = require('enyo/kind')
-	;
+	kind = require('enyo/kind'),
+	utils = require('enyo/utils');
 
 var
 	attrs = require('./globalattributes'),
-	Element = require('./Element')
-	;
+	Element = require('./Element');
 
 // https://developer.mozilla.org/en-US/docs/Web/SVG/Element/g
 module.exports = kind({
 	name: 'Group',
 	kind: Element,
 	tag: 'g',
-	supportedAttributes: enyo.merge(
+	supportedAttributes: utils.merge(
 		attrs.presentation
 	)
 });

--- a/src/Mask.js
+++ b/src/Mask.js
@@ -1,20 +1,19 @@
 require('svg');
 
 var
-	kind = require('enyo/kind')
-	;
+	kind = require('enyo/kind'),
+	utils = require('enyo/utils');
 
 var
 	attrs = require('./globalattributes'),
-	Element = require('./Element')
-	;
+	Element = require('./Element');
 
 // https://developer.mozilla.org/en-US/docs/Web/SVG/Element/mask
 module.exports = kind({
 	name: 'Mask',
 	kind: Element,
 	tag: 'mask',
-	supportedAttributes: enyo.merge(
+	supportedAttributes: utils.merge(
 		attrs.presentation,
 		[
 			'maskUnits',

--- a/src/Pattern.js
+++ b/src/Pattern.js
@@ -1,20 +1,19 @@
 require('svg');
 
 var
-	kind = require('enyo/kind')
-	;
+	kind = require('enyo/kind'),
+	utils = require('enyo/utils');
 
 var
 	attrs = require('./globalattributes'),
-	Element = require('./Element')
-	;
+	Element = require('./Element');
 
 // https://developer.mozilla.org/en-US/docs/Web/SVG/Element/pattern
 module.exports = kind({
 	name: 'Pattern',
 	kind: Element,
 	tag: 'pattern',
-	supportedAttributes: enyo.merge(
+	supportedAttributes: utils.merge(
 		attrs.presentation,
 		[
 			'viewBox',

--- a/src/Switch.js
+++ b/src/Switch.js
@@ -1,20 +1,19 @@
 require('svg');
 
 var
-	kind = require('enyo/kind')
-	;
+	kind = require('enyo/kind'),
+	utils = require('enyo/utils');
 
 var
 	attrs = require('./globalattributes'),
-	Element = require('./Element')
-	;
+	Element = require('./Element');
 
 // https://developer.mozilla.org/en-US/docs/Web/SVG/Element/switch
 module.exports = kind({
 	name: 'Switch',
 	kind: Element,
 	tag: 'switch',
-	supportedAttributes: enyo.merge(
+	supportedAttributes: utils.merge(
 		attrs.presentation,
 		[
 			'transform',

--- a/src/Symbol.js
+++ b/src/Symbol.js
@@ -1,20 +1,19 @@
 require('svg');
 
 var
-	kind = require('enyo/kind')
-	;
+	kind = require('enyo/kind'),
+	utils = require('enyo/utils');
 
 var
 	attrs = require('./globalattributes'),
-	Element = require('./Element')
-	;
+	Element = require('./Element');
 
 // https://developer.mozilla.org/en-US/docs/Web/SVG/Element/symbol
 module.exports = kind({
 	name: 'Symbol',
 	kind: Element,
 	tag: 'symbol',
-	supportedAttributes: enyo.merge(
+	supportedAttributes: utils.merge(
 		attrs.presentation,
 		[
 			'preserveAspectRatio',


### PR DESCRIPTION
### Issue
A few calls to `enyo.merge` has not yet been updated after the conversion to modules.

### Fix
These `enyo.merge` calls have been converted to `util.merge` calls, after requiring the necessary modules.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>