### PR TITLE
ENYO-3144: Use container-based infrastructure for Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: false
+language: node_js
+node_js:
+  - "node"
+cache:
+  directories:
+  - $HOME/.npm

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,7 @@ gulp.task('jshint', lint);
 
 function lint () {
 	return gulp
-		.src('./lib/**.js')
+		.src('./src/**.js')
 		.pipe(jshint())
 		.pipe(jshint.reporter(stylish, {verbose: true}))
 		.pipe(jshint.reporter('fail'));

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "description": "Easily create SVGs dynamically, using Enyo",
   "bugs": "http://jira.enyojs.com/",
   "scripts": {
-    "test": "echo 'No testing suite. Bummer!'"
+    "test": "./node_modules/.bin/gulp"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Issue
Travis builds are getting slower and slower due to being on the legacy system.

### Fix
We migrate to using the container-based infrastructure by setting `sudo: false`, per https://docs.travis-ci.com/user/migrating-from-legacy/#How-can-I-use-container-based-infrastructure%3F.

Also, we updated the path to the code from `lib` to `src`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>